### PR TITLE
Additional changes to use syslog-ng 3.6 ose images

### DIFF
--- a/syslog-ng-dev/Dockerfile
+++ b/syslog-ng-dev/Dockerfile
@@ -12,7 +12,6 @@ RUN echo 'deb http://download.opensuse.org/repositories/home:/laszlo_budai:/sysl
 ADD dev-dependencies.txt .
 RUN cat dev-dependencies.txt | grep -v "#" | xargs apt-get install -y
 
-ADD openjdk-libjvm.conf /etc/ld.so.conf.d/openjdk-libjvm.conf
 ADD libsyslog-ng.conf /etc/ld.so.conf.d/libsyslog-ng.conf
 RUN ldconfig
 

--- a/syslog-ng-dev/README.md
+++ b/syslog-ng-dev/README.md
@@ -8,7 +8,7 @@ into the container (under `/source`).
 Assume that we have cloned syslog-ng's source into the `$HOME/syslog-ng` directory. The following commands starts a container mounted with the source:
 
 ```bash
-sudo docker run --rm -it -v $HOME/syslog-ng:/source balabit/syslog-ng-dev:latest /bin/bash
+sudo docker run --rm -it -v $HOME/syslog-ng:/source balabit/syslog-ng-dev:3.6 /bin/bash
 ```
 
 Within the image you can build and install syslog-ng:
@@ -29,4 +29,3 @@ If the compilation and installation was successful you can run syslog-ng with th
 ```bash
 /install/syslog-ng -Fedv
 ```
-

--- a/syslog-ng-dev/README.md
+++ b/syslog-ng-dev/README.md
@@ -27,5 +27,5 @@ make install
 If the compilation and installation was successful you can run syslog-ng with the following command:
 
 ```bash
-/install/syslog-ng -Fedv
+/install/syslog-ng/sbin/syslog-ng -Fedv
 ```

--- a/syslog-ng-dev/dev-dependencies.txt
+++ b/syslog-ng-dev/dev-dependencies.txt
@@ -24,7 +24,6 @@ libssl-dev
 libriemann-client-dev
 libsystemd-dev
 libwrap0-dev
-openjdk-7-jdk
 uuid-dev
 # required for make
 make

--- a/syslog-ng-dev/openjdk-libjvm.conf
+++ b/syslog-ng-dev/openjdk-libjvm.conf
@@ -1,1 +1,0 @@
-/usr/lib/jvm/java-7-openjdk-amd64/jre/lib/amd64/server/

--- a/syslog-ng-incubator-dev/Dockerfile
+++ b/syslog-ng-incubator-dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM balabit/syslog-ng-dev:latest
+FROM balabit/syslog-ng-dev:3.6
 MAINTAINER Andras Mitzki <andras.mitzki@balabit.com>
 
 ENV PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/lib/pkgconfig/

--- a/syslog-ng-incubator-dev/README.md
+++ b/syslog-ng-incubator-dev/README.md
@@ -8,7 +8,7 @@ Assume that we have cloned syslog-ng-incubator's source into the `$HOME/syslog-n
 
 
 ```bash
-sudo docker run --rm -it -v $HOME/syslog-ng-incubator:/source balabit/syslog-ng-incubator-dev:latest /bin/bash
+sudo docker run --rm -it -v $HOME/syslog-ng-incubator:/source balabit/syslog-ng-incubator-dev:3.6 /bin/bash
 ```
 
 Within the image you can build and install syslog-ng-incubator:

--- a/syslog-ng-incubator-dev/README.md
+++ b/syslog-ng-incubator-dev/README.md
@@ -1,5 +1,5 @@
 # `balabit/syslog-ng-incubator-dev`
-This image provides a development environment to build and install syslog-incubator-ng from source. You have to clone the source
+This image provides a development environment to build and install syslog-ng-incubator from source. You have to clone the source
 code of [syslog-ng-incubator](https://github.com/balabit/syslog-ng-incubator.git) into a directory on your host machine then you can mount it
 into the container (under `/source`).
 

--- a/syslog-ng/Dockerfile
+++ b/syslog-ng/Dockerfile
@@ -2,11 +2,7 @@ FROM debian:latest
 MAINTAINER Andras Mitzki <andras.mitzki@balabit.com>
 
 RUN apt-get update -qq && apt-get install -y \
-    software-properties-common \
-    wget \
-    openjdk-7-jdk
-
-ADD openjdk-libjvm.conf /etc/ld.so.conf.d/openjdk-libjvm.conf
+    wget
 
 RUN wget -qO - http://download.opensuse.org/repositories/home:/laszlo_budai:/syslog-ng-3.6/Debian_8.0/Release.key | apt-key add -
 RUN echo 'deb http://download.opensuse.org/repositories/home:/laszlo_budai:/syslog-ng-3.6/Debian_8.0 ./' | tee --append /etc/apt/sources.list.d/syslog-ng-obs.list

--- a/syslog-ng/README.md
+++ b/syslog-ng/README.md
@@ -18,19 +18,19 @@ Please check the syslog-ng image tags at the official docker repository to know 
 Assume that the following ports are not used on host machine, because they can conflict: `514`, `601`:
 
 ```bash
-sudo docker run --rm -p 514:514 -p 601:601 --name syslog-ng balabit/syslog-ng:latest
+sudo docker run --rm -p 514:514 -p 601:601 --name syslog-ng balabit/syslog-ng:3.6
 ```
 By default syslog-ng will not print any debug messages to the console. If you want to see more debug messages you need to start the containers in this way:
 
 ```bash
-sudo docker run --rm -p 514:514 -p 601:601 --name syslog-ng balabit/syslog-ng:latest -edv
+sudo docker run --rm -p 514:514 -p 601:601 --name syslog-ng balabit/syslog-ng:3.6 -edv
 ```
 
 ## Using custom syslog-ng configuration
 You can override the default configuration by mounting a configuration file under `/etc/syslog-ng/syslog-ng.conf`:
 
 ```bash
-sudo docker run --rm -v "$PWD/syslog-ng.conf":/etc/syslog-ng/syslog-ng.conf balabit/syslog-ng:latest
+sudo docker run --rm -v "$PWD/syslog-ng.conf":/etc/syslog-ng/syslog-ng.conf balabit/syslog-ng:3.6
 ```
 
 ## Reading logs from other containers
@@ -58,7 +58,7 @@ log {
 Now we can start syslog-ng:
 
 ```bash
-sudo docker run --rm --volumes-from [containerID for apache2] -v "$PWD/syslog-ng.conf":/etc/syslog-ng/syslog-ng.conf balabit/syslog-ng:latest
+sudo docker run --rm --volumes-from [containerID for apache2] -v "$PWD/syslog-ng.conf":/etc/syslog-ng/syslog-ng.conf balabit/syslog-ng:3.6
 ```
 
 ## Entering into a container

--- a/syslog-ng/openjdk-libjvm.conf
+++ b/syslog-ng/openjdk-libjvm.conf
@@ -1,1 +1,0 @@
-/usr/lib/jvm/java-7-openjdk-amd64/jre/lib/amd64/server/


### PR DESCRIPTION
Bigger changes: 
- Fixed parent image tag in syslog-ng-incubator-dev image from `latest` to `3.6`. We are in `3.6` branch
- Remove openjdk installation from 3.6 docker images.

Minor changes:
- Fixed some documentation mistakes
