### PR TITLE
Upgrade version support to 3.7 on master branch

### DIFF
--- a/syslog-ng-dev/Dockerfile
+++ b/syslog-ng-dev/Dockerfile
@@ -6,13 +6,17 @@ ENV PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/local/lib/pkgconfig/
 RUN apt-get update -qq && apt-get install -y \
     wget
 
-RUN wget -qO - http://download.opensuse.org/repositories/home:/laszlo_budai:/syslog-ng-3.6/Debian_8.0/Release.key | apt-key add -
-RUN echo 'deb http://download.opensuse.org/repositories/home:/laszlo_budai:/syslog-ng-3.6/Debian_8.0 ./' | tee --append /etc/apt/sources.list.d/syslog-ng-obs.list
+RUN wget -qO - http://download.opensuse.org/repositories/home:/laszlo_budai:/syslog-ng/Debian_8.0/Release.key | apt-key add -
+RUN echo 'deb http://download.opensuse.org/repositories/home:/laszlo_budai:/syslog-ng/Debian_8.0 ./' | tee --append /etc/apt/sources.list.d/syslog-ng-obs.list
 
 ADD dev-dependencies.txt .
-RUN cat dev-dependencies.txt | grep -v "#" | xargs apt-get install -y
+RUN apt-get update -qq && cat dev-dependencies.txt | grep -v "#" | xargs apt-get install -y
+
+ADD pip-dependencies.txt .
+RUN pip install -r pip-dependencies.txt
 
 ADD libsyslog-ng.conf /etc/ld.so.conf.d/libsyslog-ng.conf
+ADD openjdk-libjvm.conf /etc/ld.so.conf.d/openjdk-libjvm.conf
 RUN ldconfig
 
 RUN mkdir /source

--- a/syslog-ng-dev/dev-dependencies.txt
+++ b/syslog-ng-dev/dev-dependencies.txt
@@ -11,6 +11,7 @@ pkg-config
 # required for configure
 bison
 flex
+gradle-2.2.1
 libcap-dev
 libdbi-dev
 libesmtp-dev
@@ -24,6 +25,7 @@ libssl-dev
 libriemann-client-dev
 libsystemd-dev
 libwrap0-dev
+openjdk-7-jdk
 uuid-dev
 # required for make
 make

--- a/syslog-ng-dev/openjdk-libjvm.conf
+++ b/syslog-ng-dev/openjdk-libjvm.conf
@@ -1,0 +1,1 @@
+/usr/lib/jvm/java-7-openjdk-amd64/jre/lib/amd64/server/

--- a/syslog-ng-dev/pip-dependencies.txt
+++ b/syslog-ng-dev/pip-dependencies.txt
@@ -1,0 +1,4 @@
+pylint
+pep8
+nose
+ply

--- a/syslog-ng/Dockerfile
+++ b/syslog-ng/Dockerfile
@@ -4,12 +4,11 @@ MAINTAINER Andras Mitzki <andras.mitzki@balabit.com>
 RUN apt-get update -qq && apt-get install -y \
     wget
 
-RUN wget -qO - http://download.opensuse.org/repositories/home:/laszlo_budai:/syslog-ng-3.6/Debian_8.0/Release.key | apt-key add -
-RUN echo 'deb http://download.opensuse.org/repositories/home:/laszlo_budai:/syslog-ng-3.6/Debian_8.0 ./' | tee --append /etc/apt/sources.list.d/syslog-ng-obs.list
+RUN wget -qO - http://download.opensuse.org/repositories/home:/laszlo_budai:/syslog-ng/Debian_8.0/Release.key | apt-key add -
+RUN echo 'deb http://download.opensuse.org/repositories/home:/laszlo_budai:/syslog-ng/Debian_8.0 ./' | tee --append /etc/apt/sources.list.d/syslog-ng-obs.list
 
 RUN apt-get update -qq && apt-get install -y \
-    syslog-ng \
-    syslog-ng-mod*
+    syslog-ng
 
 EXPOSE 514
 EXPOSE 601

--- a/syslog-ng/README.md
+++ b/syslog-ng/README.md
@@ -39,7 +39,7 @@ An example is used to describe how syslog-ng can read logs from other containers
 Assume that you have already running an `apache2` container which exposes its logs as a mounted volume under "/var/log/apache2/". We will read the apache logs and send them to a remote host (`1.2.3.4:514`). The example syslog-ng configuration file is stored in the current directory as `syslog-ng.conf`.
 
 ```
-@version: 3.6
+@version: 3.7
 
 source s_apache {
   file("/var/log/apache2/access.log");

--- a/syslog-ng/syslog-ng.conf
+++ b/syslog-ng/syslog-ng.conf
@@ -1,4 +1,4 @@
-@version: 3.6
+@version: 3.7
 
 source s_net {
   tcp(


### PR DESCRIPTION
Add support to use docker images with syslog-ng version 3.7.
