### PR TITLE
add xmllint dep

### DIFF
--- a/syslog-ng-dev/dev-dependencies.txt
+++ b/syslog-ng-dev/dev-dependencies.txt
@@ -33,4 +33,5 @@ xsltproc
 # required for make
 make
 # required for make check
+libxml2-utils
 python-pip

--- a/syslog-ng-dev/dev-dependencies.txt
+++ b/syslog-ng-dev/dev-dependencies.txt
@@ -1,11 +1,11 @@
 # other tools
-git
 gdb
+git
 strace
 vim
 # required for autogen
-autoconf-archive
 autoconf
+autoconf-archive
 automake
 libtool
 pkg-config
@@ -22,13 +22,13 @@ libglib2.0-dev
 libhiredis-dev
 libnet1-dev
 libpython-dev
-libssl-dev
 libriemann-client-dev
+libssl-dev
 libsystemd-dev
 libwrap0-dev
 openjdk-7-jdk
-uuid-dev
 python-dev
+uuid-dev
 xsltproc
 # required for make
 make


### PR DESCRIPTION
A new depencency xmllint was introduced in the unit tests of patterndb. So building and make check inside docker always failed because of this missing dependency (as reported in balabit/syslog-ng#1087).

Signed-off-by: Noémi Ványi sitbackandwait@gmail.com
