### PR TITLE
syslog-ng-dev: add Criterion as a dev-dependency

### DIFF
--- a/syslog-ng-dev/dev-dependencies.txt
+++ b/syslog-ng-dev/dev-dependencies.txt
@@ -33,5 +33,6 @@ xsltproc
 # required for make
 make
 # required for make check
+criterion-dev
 libxml2-utils
 python-pip


### PR DESCRIPTION
Partial fix for balabit/syslog-ng#1217
