### PR TITLE
syslog-ng-dev: remove libevtlog-dev from dev-dependencies

### DIFF
--- a/syslog-ng-dev/dev-dependencies.txt
+++ b/syslog-ng-dev/dev-dependencies.txt
@@ -17,7 +17,6 @@ gradle-2.2.1
 libcap-dev
 libdbi-dev
 libesmtp-dev
-libevtlog-dev
 libgeoip-dev
 libglib2.0-dev
 libhiredis-dev


### PR DESCRIPTION
eventlog has been merged into the codebase of syslog-ng.