### PR TITLE
dockerfile: add exclude-kmsg(yes) option to the system source

### DIFF
--- a/syslog-ng/Dockerfile
+++ b/syslog-ng/Dockerfile
@@ -11,6 +11,10 @@ RUN echo 'deb http://download.opensuse.org/repositories/home:/laszlo_budai:/sysl
 RUN apt-get update -qq && apt-get install -y \
     syslog-ng
 
+# With https://github.com/balabit/syslog-ng/commit/b095ac69314f3cb75aff3e873df416de22ede831
+# container detection was dropped from syslog-ng (detection was not reliable)
+RUN sed -i.bak 's/system()/system(exclude-kmsg(yes))/g' /etc/syslog-ng/syslog-ng.conf
+
 ADD openjdk-libjvm.conf /etc/ld.so.conf.d/openjdk-libjvm.conf
 RUN ldconfig
 


### PR DESCRIPTION
We dropped container detection in syslog-ng 3.17.2, because we found it unreliable. With that change the default config stopped working in containers. Thank You @xytian315 for reporting it.

Fixes: #35 

Signed-off-by: Laszlo Szemere <laszlo.szemere@balabit.com>