### PR TITLE
syslog-ng: add a docker specific default configuration

### DIFF
--- a/syslog-ng/Dockerfile
+++ b/syslog-ng/Dockerfile
@@ -11,9 +11,7 @@ RUN echo 'deb http://download.opensuse.org/repositories/home:/laszlo_budai:/sysl
 RUN apt-get update -qq && apt-get install -y \
     syslog-ng
 
-# With https://github.com/balabit/syslog-ng/commit/b095ac69314f3cb75aff3e873df416de22ede831
-# container detection was dropped from syslog-ng (detection was not reliable)
-RUN sed -i.bak 's/system()/system(exclude-kmsg(yes))/g' /etc/syslog-ng/syslog-ng.conf
+ADD syslog-ng.conf /etc/syslog-ng/syslog-ng.conf
 
 ADD openjdk-libjvm.conf /etc/ld.so.conf.d/openjdk-libjvm.conf
 RUN ldconfig

--- a/syslog-ng/syslog-ng.conf
+++ b/syslog-ng/syslog-ng.conf
@@ -1,0 +1,42 @@
+#############################################################################
+# Default syslog-ng.conf file which collects all local logs into a
+# single file called /var/log/messages tailored to container usage.
+#
+# The changes from the stock, default syslog-ng.conf file is that we've
+# dropped the system() source that is not needed and that we enabled network
+# connections using default-network-drivers(). Customize as needed and
+# override using the -v option to docker, such as:
+#
+#  docker run ...  -v "$PWD/syslog-ng.conf":/etc/syslog-ng/syslog-ng.conf
+#
+
+@version: 3.18
+@include "scl.conf"
+
+source s_local {
+	internal();
+};
+
+source s_network {
+	default-network-drivers(
+		# NOTE: TLS support
+		#
+		# the default-network-drivers() source driver opens the TLS
+		# enabled ports as well, however without an actual key/cert
+		# pair they will not operate and syslog-ng would display a
+		# warning at startup.
+		#
+		#tls(key-file("/path/to/ssl-private-key") cert-file("/path/to/ssl-cert"))
+	);
+};
+
+destination d_local {
+	file("/var/log/messages");
+	file("/var/log/messages-kv.log" template("$ISODATE $HOST $(format-welf --scope all-nv-pairs)\n") frac-digits(3));
+};
+
+log {
+	source(s_local);
+	source(s_network);
+	destination(d_local);
+};


### PR DESCRIPTION
This branch changes the default, docker supplied configuration not to use the system() driver. And also avoids the use of exclude-kmsg().

This is related to https://github.com/balabit/syslog-ng/pull/2408
