### PR TITLE
syslog-ng: Upgrade base OS to Debian Stretch

### DIFF
--- a/syslog-ng/Dockerfile
+++ b/syslog-ng/Dockerfile
@@ -1,19 +1,19 @@
-FROM debian:jessie
+FROM debian:stretch
 MAINTAINER Andras Mitzki <andras.mitzki@balabit.com>
 
 RUN apt-get update -qq && apt-get install -y \
     wget \
     gnupg2
 
-RUN wget -qO - https://download.opensuse.org/repositories/home:/laszlo_budai:/syslog-ng/Debian_8.0/Release.key | apt-key add -
-RUN echo 'deb http://download.opensuse.org/repositories/home:/laszlo_budai:/syslog-ng/Debian_8.0 ./' | tee --append /etc/apt/sources.list.d/syslog-ng-obs.list
+RUN wget -qO - https://download.opensuse.org/repositories/home:/laszlo_budai:/syslog-ng/Debian_9.0/Release.key | apt-key add -
+RUN echo 'deb http://download.opensuse.org/repositories/home:/laszlo_budai:/syslog-ng/Debian_9.0 ./' | tee --append /etc/apt/sources.list.d/syslog-ng-obs.list
 
 RUN apt-get update -qq && apt-get install -y \
     syslog-ng
 
 ADD syslog-ng.conf /etc/syslog-ng/syslog-ng.conf
 
-ADD openjdk-libjvm.conf /etc/ld.so.conf.d/openjdk-libjvm.conf
+RUN find /usr/lib/ -name 'libjvm.so*' | xargs dirname | tee --append /etc/ld.so.conf.d/openjdk-libjvm.conf
 RUN ldconfig
 
 EXPOSE 514/udp

--- a/syslog-ng/openjdk-libjvm.conf
+++ b/syslog-ng/openjdk-libjvm.conf
@@ -1,1 +1,0 @@
-/usr/lib/jvm/java-7-openjdk-amd64/jre/lib/amd64/server/


### PR DESCRIPTION
 - it was triggered because Debian Jessie repos
can not be updated
 - related URLs:
https://lists.debian.org/debian-devel-announce/2019/03/msg00006.html
https://github.com/docker-library/official-images/issues/3551
https://github.com/debuerreotype/docker-debian-artifacts/issues/66


Signed-off-by: Andras Mitzki <andras.mitzki@balabit.com>