### PR TITLE
Minor improvements to Docker based syslog-ng

### DIFF
--- a/syslog-ng/Dockerfile
+++ b/syslog-ng/Dockerfile
@@ -1,23 +1,27 @@
 FROM debian:stretch
 MAINTAINER Andras Mitzki <andras.mitzki@balabit.com>
 
-RUN apt-get update -qq && apt-get install -y \
+RUN apt-get update -qq && \
+    apt-get install -y \
     wget \
-    gnupg2
-
-RUN wget -qO - https://download.opensuse.org/repositories/home:/laszlo_budai:/syslog-ng/Debian_9.0/Release.key | apt-key add -
-RUN echo 'deb http://download.opensuse.org/repositories/home:/laszlo_budai:/syslog-ng/Debian_9.0 ./' | tee --append /etc/apt/sources.list.d/syslog-ng-obs.list
+    gnupg2 && \
+    wget -qO - https://download.opensuse.org/repositories/home:/laszlo_budai:/syslog-ng/Debian_9.0/Release.key | apt-key add - &&\
+    echo 'deb http://download.opensuse.org/repositories/home:/laszlo_budai:/syslog-ng/Debian_9.0 ./' | tee --append /etc/apt/sources.list.d/syslog-ng-obs.list && \
+    apt-get clean
 
 RUN apt-get update -qq && apt-get install -y \
-    syslog-ng
+    syslog-ng && \
+    apt-get clean && \
+    find /usr/lib/ -name 'libjvm.so*' | xargs dirname | tee --append /etc/ld.so.conf.d/openjdk-libjvm.conf && \
+    ldconfig && \
+    mkdir -p /etc/syslog-ng/conf.d
 
 ADD syslog-ng.conf /etc/syslog-ng/syslog-ng.conf
 
-RUN find /usr/lib/ -name 'libjvm.so*' | xargs dirname | tee --append /etc/ld.so.conf.d/openjdk-libjvm.conf
-RUN ldconfig
+RUN syslog-ng -s --no-caps
 
 EXPOSE 514/udp
 EXPOSE 601/tcp
 EXPOSE 6514/tcp
-
-ENTRYPOINT ["/usr/sbin/syslog-ng", "-F"]
+#In Docker context no need to manage capabilities
+ENTRYPOINT ["/usr/sbin/syslog-ng", "-F","--no-caps"]

--- a/syslog-ng/README.md
+++ b/syslog-ng/README.md
@@ -27,11 +27,13 @@ sudo docker run -it -p 514:514/udp -p 601:601 --name syslog-ng balabit/syslog-ng
 ```
 
 ## Using custom syslog-ng configuration
-You can override the default configuration by mounting a configuration file under `/etc/syslog-ng/syslog-ng.conf`:
+You can extend the default configuration by mounting a configuration folder under `/etc/syslog-ng/conf.d/syslog-ng.conf`:
 
 ```bash
-sudo docker run -it -v "$PWD/syslog-ng.conf":/etc/syslog-ng/syslog-ng.conf balabit/syslog-ng:latest
+sudo docker run -it -v "$PWD/conf.d":/etc/syslog-ng/conf.d balabit/syslog-ng:latest
 ```
+
+The docker container does not accept any input by default a configuration file containing source, destination and log definitions is required.
 
 ## Reading logs from other containers
 An example is used to describe how syslog-ng can read logs from other containers.
@@ -80,4 +82,3 @@ If the given configuration requires, syslog-ng tries to set some POSIX capabilit
  * If you do not require any capability (i.e. don't want to listen on ports under 1024 - NET_BIND_SERVICE), simply start syslog-ng with the `--no-caps` option.
  * If you know precisely the type of capability you need, use the `--cap-add` option of the Docker service.
  * (For development/testing purpose only!) To grant ALL of the capabilities to your container, start it with the `privileged` option. However, we do not recommend this method in production environments.
-

--- a/syslog-ng/syslog-ng.conf
+++ b/syslog-ng/syslog-ng.conf
@@ -10,33 +10,22 @@
 #  docker run ...  -v "$PWD/syslog-ng.conf":/etc/syslog-ng/syslog-ng.conf
 #
 
-@version: 3.18
+@version: 3.21
 @include "scl.conf"
 
 source s_local {
 	internal();
 };
 
-source s_network {
-	default-network-drivers(
-		# NOTE: TLS support
-		#
-		# the default-network-drivers() source driver opens the TLS
-		# enabled ports as well, however without an actual key/cert
-		# pair they will not operate and syslog-ng would display a
-		# warning at startup.
-		#
-		#tls(key-file("/path/to/ssl-private-key") cert-file("/path/to/ssl-cert"))
-	);
-};
 
 destination d_local {
-	file("/var/log/messages");
-	file("/var/log/messages-kv.log" template("$ISODATE $HOST $(format-welf --scope all-nv-pairs)\n") frac-digits(3));
+	pipe("/dev/xconsole");
 };
 
+#internal events should log out to console so docker logging driver can find them
 log {
 	source(s_local);
-	source(s_network);
 	destination(d_local);
 };
+
+@include "conf.d/*.conf"

--- a/syslog-ng/syslog-ng.conf
+++ b/syslog-ng/syslog-ng.conf
@@ -17,6 +17,18 @@ source s_local {
 	internal();
 };
 
+source s_network {
+	default-network-drivers(
+		# NOTE: TLS support
+		#
+		# the default-network-drivers() source driver opens the TLS
+		# enabled ports as well, however without an actual key/cert
+		# pair they will not operate and syslog-ng would display a
+		# warning at startup.
+		#
+		#tls(key-file("/path/to/ssl-private-key") cert-file("/path/to/ssl-cert"))
+	);
+};
 
 destination d_local {
 	pipe("/dev/xconsole");
@@ -29,3 +41,9 @@ log {
 };
 
 @include "conf.d/*.conf"
+
+#internal events should log out to console so docker logging driver can find them
+log {
+	source(s_network);
+	destination(d_local);
+};


### PR DESCRIPTION
-Improved DockerFile to reduce number and size of layers
-Internal logs output to console for Docker log driver
-Allow configure by Include so end users don't have to maintain base configuration only site specific logic.
-Update readme