### PR TITLE
syslog-ng: update default config for containers

### DIFF
--- a/syslog-ng/syslog-ng.conf
+++ b/syslog-ng/syslog-ng.conf
@@ -10,7 +10,7 @@
 #  docker run ...  -v "$PWD/syslog-ng.conf":/etc/syslog-ng/syslog-ng.conf
 #
 
-@version: 3.18
+@version: 3.29
 @include "scl.conf"
 
 source s_local {


### PR DESCRIPTION
Just eliminate the compatibility warning for a while 
(we don't need to version bump on every new release, until the next config-version upgrade, more about config version: #3074)

We could use the the `@version: current` form as well (#3369)
