### PR TITLE
helm: Add Config SHA to Deployment to trigger redeploy

### DIFF
--- a/syslog-ng-helm-chart/templates/deployment.yaml
+++ b/syslog-ng-helm-chart/templates/deployment.yaml
@@ -13,8 +13,9 @@ spec:
       {{- include "syslog-ng.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-    {{- with .Values.podAnnotations }}
       annotations:
+        checksum/config: {{ tpl (toYaml .Values.config) . | sha256sum }}
+    {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
     {{- end }}
       labels:
@@ -55,7 +56,7 @@ spec:
         persistentVolumeClaim:
           claimName: {{ include "syslog-ng.fullname" . }}-pvc
       {{- end }}
-      
+
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
When making changes to the config, it currently requires a manual re-deploy for the changes to be pushed live. (Updating a ConfigMap doesn't trigger a deploy).

This change follows the [best practice/tip from helm](https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments) to include a config hash in the Annotations which when updated, then triggers a redeploy.


eg. default values:
```
$ helm template . | grep -B1 checksum/config
      annotations:
        checksum/config: ad02c0dc6a6f70b346faeff271614c764b0dd7278f1050375779e0e069fd1382
```
