### PR TITLE
Helm: separate services for udp/tcp

### DIFF
--- a/syslog-ng-helm-chart/templates/service.yaml
+++ b/syslog-ng-helm-chart/templates/service.yaml
@@ -1,12 +1,16 @@
+{{- /*
+While the ServiceType "LoadBalancer" doesn't support mutliple protocols, 2
+Service objects are needed.
+*/}}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "syslog-ng.fullname" . }}
+  name: {{ include "syslog-ng.fullname" . }}-udp
   labels:
     {{- include "syslog-ng.labels" . | nindent 4 }}
 spec:
   {{- if eq .Values.service.type "externalip" }}
-  
+
   {{- with .Values.service.externalIPs }}
   externalIPs:
     {{- toYaml . | nindent 3 }}
@@ -19,9 +23,29 @@ spec:
       port: 514
       targetPort: 514
       protocol: UDP
+  selector:
+    {{- include "syslog-ng.selectorLabels" . | nindent 4 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "syslog-ng.fullname" . }}-tcp
+  labels:
+    {{- include "syslog-ng.labels" . | nindent 4 }}
+spec:
+  {{- if eq .Values.service.type "externalip" }}
+
+  {{- with .Values.service.externalIPs }}
+  externalIPs:
+    {{- toYaml . | nindent 3 }}
+  {{- end }}
+  {{- else}}
+  type: {{ .Values.service.type }}
+  {{- end }}
+  ports:
     - name: tcp-port
       port: 601
       targetPort: 601
-      protocol: TCP 
+      protocol: TCP
   selector:
     {{- include "syslog-ng.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
Hi, For the helm chart, I see that the LoadBalancer is marked Todo:

https://github.com/balabit/syslog-ng-docker/blob/910cc1f0745d2343eff763f848000f69724f76bd/syslog-ng-helm-chart/values.yaml#L79

I assume this was due to the LB not currently supporting multiple protocols ([note: this is an v1.20 Alpha feature](https://kubernetes.io/docs/concepts/services-networking/service/#load-balancers-with-mixed-protocol-types)).

My suggestion is to probably always create 2 service objects? One could do further complex logic to only create 2 when a LB is created, but that seems excessive?

Once upstream Kubernetes adds full support for multiple LB protocols, this can be reverted.

```
$ helm template .
[...]

---
# Source: syslog-ng/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: RELEASE-NAME-syslog-ng-udp
  labels:
    helm.sh/chart: syslog-ng-0.2
    app.kubernetes.io/name: syslog-ng
    app.kubernetes.io/instance: RELEASE-NAME
    app.kubernetes.io/version: "3.27.1"
    app.kubernetes.io/managed-by: Helm
spec:
  type: ClusterIP
  ports:
    - name: udp-port
      port: 514
      targetPort: 514
      protocol: UDP
  selector:
    app.kubernetes.io/name: syslog-ng
    app.kubernetes.io/instance: RELEASE-NAME
---
# Source: syslog-ng/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: RELEASE-NAME-syslog-ng-tcp
  labels:
    helm.sh/chart: syslog-ng-0.2
    app.kubernetes.io/name: syslog-ng
    app.kubernetes.io/instance: RELEASE-NAME
    app.kubernetes.io/version: "3.27.1"
    app.kubernetes.io/managed-by: Helm
spec:
  type: ClusterIP
  ports:
    - name: tcp-port
      port: 601
      targetPort: 601
      protocol: TCP
  selector:
    app.kubernetes.io/name: syslog-ng
    app.kubernetes.io/instance: RELEASE-NAME
---

[...]
```