### PR TITLE
Auto tag images

### DIFF
--- a/syslog-ng/Dockerfile
+++ b/syslog-ng/Dockerfile
@@ -1,6 +1,8 @@
 FROM debian:stretch
 LABEL maintainer="Andras Mitzki <andras.mitzki@balabit.com>"
 
+ARG SYSLOG_NG_VERSION
+RUN [ -n "${SYSLOG_NG_VERSION}" ] # Please provide the version of syslog-ng you wish to install. i.e.: --build-arg SYSLOG_NG_VERSION=3.31.2-1, or use the keyword "master" to install the latest version.
 
 RUN apt-get update -qq && apt-get install -y \
     wget \
@@ -8,9 +10,10 @@ RUN apt-get update -qq && apt-get install -y \
 
 RUN wget -qO - https://download.opensuse.org/repositories/home:/laszlo_budai:/syslog-ng/Debian_9.0/Release.key | apt-key add -
 RUN echo 'deb http://download.opensuse.org/repositories/home:/laszlo_budai:/syslog-ng/Debian_9.0 ./' | tee --append /etc/apt/sources.list.d/syslog-ng-obs.list
+RUN apt-get update -qq
 
-RUN apt-get update -qq && apt-get install -y \
-    libdbd-mysql libdbd-pgsql libdbd-sqlite3 syslog-ng
+COPY install_syslog_ng_version.sh /tmp/
+RUN /tmp/install_syslog_ng_version.sh ${SYSLOG_NG_VERSION}
 
 ADD syslog-ng.conf /etc/syslog-ng/syslog-ng.conf
 

--- a/syslog-ng/hooks/build
+++ b/syslog-ng/hooks/build
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker build --build-arg SYSLOG_NG_VERSION=${SOURCE_BRANCH} -f $DOCKERFILE_PATH -t $IMAGE_NAME .

--- a/syslog-ng/install_syslog_ng_version.sh
+++ b/syslog-ng/install_syslog_ng_version.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# This script tries to install a specific version of Syslog-ng. (or the "latest" version)
+
+# The problem is that apt-get do not preserve the version number while
+# it is resolving metapackage dependencies. (Which is logical. If there
+# is any version restriction we should list them in the metapackage.)
+# 
+# example:
+#   We have a metapackage "foo", which lists "biz" and "baz" as
+#   dependencies. The command apt-get install foo=42, will install
+#   the latest greatest version of the biz and baz packages.
+# 
+# Since the dependencies of the syslog-ng metapackage can change from
+# version to version, (adding or removing modules) we can not hardcode
+# the package list in the apt-get command.
+# 
+# As a workaround this script queries the list of the dependencies of
+# the specific version of the syslog-ng metapackage. Parses the output,
+# than generates an apt-get install command where each package has the
+# same fixed version number in the form of <package-name>=VERSION.
+
+
+if [ $# -eq 0 ]; then
+    echo "Please provide the version number you wish to install as a first parameter of the script. (This sciprt is intended to use from the Dockerfile, maybe you are executing it by a mistake.)"
+    exit 1;
+else
+    SYSLOG_NG_VERSION=$1
+fi
+
+
+if [ "$SYSLOG_NG_VERSION" = "master" ]; then
+    SYSLOG_NG_INSTALL_STRING="syslog-ng"
+else
+    NUMBER_OF_MATCHING_VERSIONS=$(apt-cache madison syslog-ng | awk '{print $3}' | grep -c $SYSLOG_NG_VERSION)
+    if [ $NUMBER_OF_MATCHING_VERSIONS -eq 0 ]; then
+        echo "Unable to find a matching version of Syslog-ng ($SYSLOG_NG_VERSION)"
+        exit 1;
+    elif [ $NUMBER_OF_MATCHING_VERSIONS -gt 1 ]; then
+        echo "Version number is ambiguous, there are more than one matching Syslog-ng version: ($SYSLOG_NG_VERSION)";
+        exit 1;
+    fi
+
+    SYSLOG_NG_INSTALL_STRING=$(LANG=C apt-cache depends syslog-ng=$SYSLOG_NG_VERSION | sed -n -r 's/\s+(Recommends|Depends): ([a-z0-9-]+)/\2='"$SYSLOG_NG_VERSION"'/p' | tr '\n' ' ')
+fi
+
+
+
+# The package manager is intentionally the last command of this script.
+# If you change this, please store the exit code and return it manually.
+
+echo "Syslog-ng will be installed with the following apt-get command: apt-get install -y libdbd-mysql libdbd-pgsql libdbd-sqlite3 $SYSLOG_NG_INSTALL_STRING"
+apt-get install -y libdbd-mysql libdbd-pgsql libdbd-sqlite3 $SYSLOG_NG_INSTALL_STRING


### PR DESCRIPTION
The aim of this pull request is to implement automatic image tagging on DockerHub.

The pull request has two main components: (I tried to explain both of them in details in their related commit message.)
1) Make sure we install the right package during image build.
2) Tag the image on DockerHub. (Beside the commit, this step also requires a configuration step on the DockerHub GUI. Do not merge this PR until it is done.)


## Our current process:
1) We trigger a Docker image build manually on DockerHub from the current master branch.
2) When the image is ready, we check the build log if it contains the new version of Syslog-ng (note: the current implementation can ONLY install the latest version)
3) We download the (latest) image, tag it, and push it back to DockerHub. (Docker is clever, it will reuse the laysers, and only push the new tag.)

## The new process will be:
1) We create a new release in this repository.
It will automatically trigger a new build on DockerHub, and tag the final image. IF the version of syslog-ng is not available, the build will fail.
