### PR TITLE
Switch to OSE APT repo and upgrade image to Debian Testing

### DIFF
--- a/syslog-ng/Dockerfile
+++ b/syslog-ng/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM debian:testing
 LABEL maintainer="Andras Mitzki <andras.mitzki@balabit.com>"
 
 
@@ -7,7 +7,7 @@ RUN apt-get update -qq && apt-get install -y \
     gnupg2
 
 RUN wget -qO - https://ose-repo.syslog-ng.com/apt/syslog-ng-ose-pub.asc | apt-key add - && \
-  echo "deb https://ose-repo.syslog-ng.com/apt/ stable debian-buster" | tee --append /etc/apt/sources.list.d/syslog-ng-ose.list
+  echo "deb https://ose-repo.syslog-ng.com/apt/ stable debian-testing" | tee --append /etc/apt/sources.list.d/syslog-ng-ose.list
 
 RUN apt-get update -qq && apt-get install -y \
     libdbd-mysql libdbd-pgsql libdbd-sqlite3 syslog-ng

--- a/syslog-ng/Dockerfile
+++ b/syslog-ng/Dockerfile
@@ -6,8 +6,8 @@ RUN apt-get update -qq && apt-get install -y \
     wget \
     gnupg2
 
-RUN wget -qO - https://ose-repo.syslog-ng.com/apt/syslog-ng-ose-pub.asc | apt-key add - && \
-  echo "deb https://ose-repo.syslog-ng.com/apt/ stable debian-testing" | tee --append /etc/apt/sources.list.d/syslog-ng-ose.list
+RUN wget -qO - https://ose-repo.syslog-ng.com/apt/syslog-ng-ose-pub.asc | gpg --dearmor > /usr/share/keyrings/ose-repo-archive-keyring.gpg && \
+  echo "deb [ signed-by=/usr/share/keyrings/ose-repo-archive-keyring.gpg ] https://ose-repo.syslog-ng.com/apt/ stable debian-testing" | tee --append /etc/apt/sources.list.d/syslog-ng-ose.list
 
 RUN apt-get update -qq && apt-get install -y \
     libdbd-mysql libdbd-pgsql libdbd-sqlite3 syslog-ng

--- a/syslog-ng/Dockerfile
+++ b/syslog-ng/Dockerfile
@@ -4,6 +4,7 @@ LABEL maintainer="Andras Mitzki <andras.mitzki@balabit.com>"
 
 RUN apt-get update -qq && apt-get install -y \
     wget \
+    ca-certificates \
     gnupg2
 
 RUN wget -qO - https://ose-repo.syslog-ng.com/apt/syslog-ng-ose-pub.asc | gpg --dearmor > /usr/share/keyrings/ose-repo-archive-keyring.gpg && \

--- a/syslog-ng/Dockerfile
+++ b/syslog-ng/Dockerfile
@@ -14,9 +14,6 @@ RUN apt-get update -qq && apt-get install -y \
 
 ADD syslog-ng.conf /etc/syslog-ng/syslog-ng.conf
 
-RUN find /usr/lib/ -name 'libjvm.so*' | xargs dirname | tee --append /etc/ld.so.conf.d/openjdk-libjvm.conf
-RUN ldconfig
-
 EXPOSE 514/udp
 EXPOSE 601/tcp
 EXPOSE 6514/tcp

--- a/syslog-ng/Dockerfile
+++ b/syslog-ng/Dockerfile
@@ -6,8 +6,8 @@ RUN apt-get update -qq && apt-get install -y \
     wget \
     gnupg2
 
-RUN wget -qO - https://download.opensuse.org/repositories/home:/laszlo_budai:/syslog-ng/Debian_10/Release.key | apt-key add -
-RUN echo 'deb http://download.opensuse.org/repositories/home:/laszlo_budai:/syslog-ng/Debian_10 ./' | tee --append /etc/apt/sources.list.d/syslog-ng-obs.list
+RUN wget -qO - https://ose-repo.syslog-ng.com/apt/syslog-ng-ose-pub.asc | apt-key add - && \
+  echo "deb https://ose-repo.syslog-ng.com/apt/ stable debian-buster" | tee --append /etc/apt/sources.list.d/syslog-ng-ose.list
 
 RUN apt-get update -qq && apt-get install -y \
     libdbd-mysql libdbd-pgsql libdbd-sqlite3 syslog-ng


### PR DESCRIPTION
See: https://github.com/syslog-ng/syslog-ng#readme

We make our release tarballs on Debian Testing, so using a rolling release for the production image is fine.